### PR TITLE
Add 42 since it works there too

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
  "gettext-domain": "gnome-shell-extensions",
  "name": "Miniview",
  "description": "Show window previews",
- "shell-version": [ "40.alpha", "40.beta", "40" , "41" ],
+ "shell-version": [ "40.alpha", "40.beta", "40" , "41", "42" ],
  "original-authors": [ "thesecretaryofwar@gmail.com" ],
  "url": "https://github.com/iamlemec/miniview"
 }


### PR DESCRIPTION
Tested on Ubuntu Jammy Jellyfish + GNOME PPA with gnome-shell 42~alpha.

Preferences works too.

Thanks for this nice and useful extension.